### PR TITLE
Update raspberrypi4b_driver_bmp280_interface.c

### DIFF
--- a/project/raspberrypi4b/driver/src/raspberrypi4b_driver_bmp280_interface.c
+++ b/project/raspberrypi4b/driver/src/raspberrypi4b_driver_bmp280_interface.c
@@ -196,5 +196,5 @@ void bmp280_interface_debug_print(const char *const fmt, ...)
     va_end(args);
     
     len = strlen((char *)str);
-    (void)printf((uint8_t *)str, len);
+    printf("%s\n", str);
 }


### PR DESCRIPTION
fix an error in printf function.


